### PR TITLE
Add tests for scheme.futu

### DIFF
--- a/modules/core/src/main/scala/qq/droste/data/Mu.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Mu.scala
@@ -22,6 +22,7 @@ object Mu {
   def coalgebra[F[_]: Functor]: Coalgebra[F, Mu[F]] =
     mf => mf[F[Mu[F]]](_ map algebra)
 
+  def apply  [F[_]: Functor](fmf: F[Mu[F]]):   Mu[F]  = embed(fmf)
   def embed  [F[_]: Functor](fmf: F[Mu[F]]):   Mu[F]  = algebra  [F].apply(fmf)
   def project[F[_]: Functor](mf :   Mu[F] ): F[Mu[F]] = coalgebra[F].apply(mf)
 

--- a/modules/core/src/main/scala/qq/droste/data/Nu.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Nu.scala
@@ -29,6 +29,7 @@ object Nu {
   def coalgebra[F[_]: Functor]: Coalgebra[F, Nu[F]] =
     nf => nf.unfold(nf.a) map (MuEqA(nf.unfold, _))
 
+  def apply  [F[_]: Functor](fnf: F[Nu[F]]):   Nu[F]  = embed(fnf)
   def embed  [F[_]: Functor](fnf: F[Nu[F]]):   Nu[F]  = algebra  [F].apply(fnf)
   def project[F[_]: Functor](nf :   Nu[F] ): F[Nu[F]] = coalgebra[F].apply(nf)
 

--- a/modules/core/src/main/scala/qq/droste/data/list.scala
+++ b/modules/core/src/main/scala/qq/droste/data/list.scala
@@ -14,6 +14,22 @@ final case class ConsF[A, B](head: A, tail: B) extends ListF[A, B]
 case object NilF extends ListF[Nothing, Nothing]
 
 object ListF {
+
+  def toScalaList[A, PatR[_[_]]](list: PatR[ListF[A, ?]])(
+    implicit ev1: Project[ListF[A, ?], PatR[ListF[A, ?]]]
+  ): List[A] =
+    scheme.cata(toScalaListAlgebra[A]).apply(list)
+
+  def toScalaListAlgebra[A]: Algebra[ListF[A, ?], List[A]] = {
+    case ConsF(head, tail) => head :: tail
+    case NilF              => Nil
+  }
+
+  def fromScalaListCoalgebra[A]: Coalgebra[ListF[A, ?], List[A]] = {
+    case head :: tail => ConsF(head, tail)
+    case Nil          => NilF
+  }
+
   implicit def drosteTraverseForListF[A]: Traverse[ListF[A, ?]] =
     new DefaultTraverse[ListF[A, ?]] {
       def traverse[F[_]: Applicative, B, C](fb: ListF[A, B])(f: B => F[C]): F[ListF[A, C]] =

--- a/modules/core/src/main/scala/qq/droste/data/list.scala
+++ b/modules/core/src/main/scala/qq/droste/data/list.scala
@@ -16,7 +16,7 @@ case object NilF extends ListF[Nothing, Nothing]
 object ListF {
 
   def toScalaList[A, PatR[_[_]]](list: PatR[ListF[A, ?]])(
-    implicit ev1: Project[ListF[A, ?], PatR[ListF[A, ?]]]
+    implicit ev: Project[ListF[A, ?], PatR[ListF[A, ?]]]
   ): List[A] =
     scheme.cata(toScalaListAlgebra[A]).apply(list)
 
@@ -24,6 +24,11 @@ object ListF {
     case ConsF(head, tail) => head :: tail
     case NilF              => Nil
   }
+
+  def fromScalaList[A, PatR[_[_]]](list: List[A])(
+    implicit ev: Embed[ListF[A, ?], PatR[ListF[A, ?]]]
+  ): PatR[ListF[A, ?]] =
+    scheme.ana(fromScalaListCoalgebra[A]).apply(list)
 
   def fromScalaListCoalgebra[A]: Coalgebra[ListF[A, ?], List[A]] = {
     case head :: tail => ConsF(head, tail)

--- a/modules/core/src/main/scala/qq/droste/data/package.scala
+++ b/modules/core/src/main/scala/qq/droste/data/package.scala
@@ -45,6 +45,7 @@ object `package` {
     def unfree[F[_], A](f: Free[F, A]): Either[A, F[Free[F, A]]] = macro Meta.fastCast
 
     def pure[F[_], A](a: A): Free[F, A] = free(Left(a))
+    def roll[F[_], A](fa: F[Free[F, A]]): Free[F, A] = free(Right(fa))
 
     final class Ops[F[_], A](val free: Free[F, A]) extends AnyVal {
       def fold[B](fa: A => B, ffffa: F[Free[F, A]] => B): B =

--- a/modules/tests/src/test/scala/qq/droste/examples/futu/ListExchange.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/futu/ListExchange.scala
@@ -1,0 +1,41 @@
+package qq.droste
+package examples.futu
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import qq.droste.data.list._
+import qq.droste.data.Fix
+import qq.droste.data.Free
+
+final class ListExchange extends Properties("ListExchange") {
+
+  type FixedList[A] = Fix[ListF[A, ?]]
+
+  // TODO: make this more ergonomic to write
+  val exchangeCoalgebra: CVCoalgebra[ListF[String, ?], FixedList[String]] = Fix.unfix(_) match {
+    case NilF => NilF
+    case ConsF(head, tail) => Fix.unfix(tail) match {
+      case NilF => ConsF(head, Free.pure(tail))
+      case ConsF(tailHead, tailTail) =>
+        ConsF(tailHead, Free.roll(
+          ConsF(head, Free.pure[ListF[String, ?], FixedList[String]](tailTail))))
+    }
+  }
+
+  val f: List[String] => List[String] =
+    scheme.futu(exchangeCoalgebra) andThen
+    (ListF.toScalaList(_)) compose
+    (ListF.fromScalaList(_))
+
+  property("simple pair wise swap check") = {
+    val in: List[String] = List("a", "b", "c", "d", "e", "f")
+    val expected: List[String] = List("b", "a", "d", "c", "f", "e")
+    f(in) ?= expected
+  }
+
+  property("pair wise swap") =
+    forAll((in: List[String]) =>
+      f(in) ?= in.sliding(2, 2).map(_.reverse).toList.flatten)
+
+}

--- a/modules/tests/src/test/scala/qq/droste/tests/ListTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/ListTests.scala
@@ -1,0 +1,51 @@
+package qq.droste
+package tests
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import qq.droste.data.list._
+import qq.droste.data.Fix
+import qq.droste.data.Mu
+import qq.droste.data.Nu
+
+final class ListTests extends Properties("ListTest") {
+
+  property("Fix ListF -> List") = {
+    val fixed: Fix[ListF[Int, ?]] =
+      Fix(ConsF(1,
+        Fix(ConsF(2,
+          Fix(ConsF(3,
+            Fix(NilF: ListF[Int, Fix[ListF[Int, ?]]])))))))
+
+    ListF.toScalaList(fixed) ?= 1 :: 2 :: 3 :: Nil
+  }
+
+  property("Mu ListF -> List") = {
+    val mu: Mu[ListF[Int, ?]] =
+      Mu(ConsF(1,
+        Mu(ConsF(2,
+          Mu(ConsF(3,
+            Mu(NilF: ListF[Int, Mu[ListF[Int, ?]]])))))))
+
+    ListF.toScalaList(mu) ?= 1 :: 2 :: 3 :: Nil
+  }
+
+  property("Nu ListF -> List") = {
+    val nu: Nu[ListF[Int, ?]] =
+      Nu(ConsF(1,
+        Nu(ConsF(2,
+          Nu(ConsF(3,
+            Nu(NilF: ListF[Int, Nu[ListF[Int, ?]]])))))))
+
+    ListF.toScalaList(nu) ?= 1 :: 2 :: 3 :: Nil
+  }
+
+  property("rountrip List") = {
+    // TODO: is there a way to rework/augment some of the schemes to return a
+    // natural transformation valid for all lists?
+    val f = scheme.hylo(ListF.toScalaListAlgebra[String], ListF.fromScalaListCoalgebra[String])
+    forAll((list: List[String]) => f(list) ?= list)
+  }
+
+}


### PR DESCRIPTION
Adds a test/example for using `scheme.futu`.

As it stands the ergonomics of using this method are really poor-- to the point where it's pretty ugly to write simple logic. I'll work on cleaning this up in a future PR; for now I'm just happy with the increased test coverage.