### PR TITLE
Split function based hylo to kernel object

### DIFF
--- a/modules/core/src/main/scala/qq/droste/kernel.scala
+++ b/modules/core/src/main/scala/qq/droste/kernel.scala
@@ -1,0 +1,96 @@
+package qq.droste
+
+import cats.Functor
+import cats.Monad
+import cats.Traverse
+
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
+
+import implicits.composedFunctor._
+import syntax.alias._
+
+/** Fundamental recursion schemes implemented in terms of
+  * functions and nothing else.
+  *
+  */
+object kernel {
+
+  /** Build a hylomorphism by recursively unfolding with `coalgebra` and
+    * refolding with `algebra`.
+    *
+    * <pre>
+    *                  hylo
+    *          A ---------------> B
+    *          |                  ^
+    *  co-     |                  |
+    * algebra  |                  | algebra
+    *          |                  |
+    *          v                  |
+    *         F[A] ------------> F[B]
+    *                map hylo
+    * </pre>
+    *
+    * @group refolds
+    *
+    * @usecase def hylo[F[_], A, B](algebra: F[B] => B, coalgebra: A => F[A]): A => B
+    *   @inheritdoc
+    */
+  def hylo[F[_]: Functor, A, B](
+    algebra  : F[B] => B,
+    coalgebra: A    => F[A]
+  ): A => B =
+    new (A => B) {
+      def apply(a: A): B = algebra(coalgebra(a).map(this))
+    }
+
+  /** Convenience to build a hylomorphism for the composed functor `F[G[_]]`.
+    *
+    * This is strictly for convenience and just delegates
+    * to `hylo` with the types set properly.
+    *
+    * @group refolds
+    *
+    * @usecase def hyloC[F[_], G[_], A, B](algebra: F[G[B]] => B, coalgebra: A => F[G[A]]): A => B
+    *   @inheritdoc
+    */
+  @inline def hyloC[F[_]: Functor, G[_]: Functor, A, B](
+    algebra  : F[G[B]] => B,
+    coalgebra: A       => F[G[A]]
+  ): A => B = hylo[(F ∘ G)#λ, A, B](algebra, coalgebra)
+
+  /** Build a monadic hylomorphism
+    *
+    * <pre>
+    *                 hyloM
+    *          A ---------------> M[B]
+    *          |                  ^
+    *  co-     |                  |
+    * algebraM |                  | flatMap f
+    *          |                  |
+    *          v                  |
+    *       M[F[A]] ---------> M[F[M[B]]]
+    *               map hyloM
+    *
+    * with f:
+    *
+    * F[M[B]] -----> M[F[B]] ----------> M[B]
+    *       sequence          flatMap
+    *                         algebraM
+    * </pre>
+    *
+    * @group refolds
+    *
+    * @usecase def hyloM[M[_], F[_], A, B](algebra: F[B] => M[B], coalgebra: A => M[F[A]]): A => M[B]
+    *   @inheritdoc
+    */
+  def hyloM[M[_]: Monad, F[_]: Traverse, A, B](
+    algebra  : F[B] => M[B],
+    coalgebra: A => M[F[A]]
+  ): A => M[B] =
+    hyloC[M, F, A, M[B]](
+      _.flatMap(_.sequence.flatMap(algebra)),
+      coalgebra)
+
+}

--- a/modules/core/src/main/scala/qq/droste/zoo.scala
+++ b/modules/core/src/main/scala/qq/droste/zoo.scala
@@ -26,7 +26,7 @@ private[droste] trait Zoo {
   def apo[F[_]: Functor, A, R](
     coalgebra: RCoalgebra[R, F, A]
   )(implicit embed: Embed[F, R]): A => R =
-    scheme.hyloC(
+    kernel.hyloC(
       embed.algebra.run.compose((frr: F[(R | R)]) => frr.map(_.merge)),
       coalgebra.run)
 
@@ -46,7 +46,7 @@ private[droste] trait Zoo {
   def para[F[_]: Functor, R, B](
     algebra: RAlgebra[R, F, B]
   )(implicit project: Project[F, R]): R => B =
-    scheme.hyloC(
+    kernel.hyloC(
       algebra.run,
       project.coalgebra.run.andThen(_.map(r => (r, r))))
 
@@ -61,7 +61,7 @@ private[droste] trait Zoo {
   def histo[F[_]: Functor, R, B](
     algebra: CVAlgebra[F, B]
   )(implicit project: Project[F, R]): R => B =
-    scheme.hylo[F, R, Cofree[F, B]](
+    kernel.hylo[F, R, Cofree[F, B]](
       fb => Cofree(algebra(fb), fb),
       project.coalgebra.run
     ) andThen (_.head)
@@ -76,7 +76,7 @@ private[droste] trait Zoo {
   def futu[F[_]: Functor, A, R](
     coalgebra: CVCoalgebra[F, A]
   )(implicit embed: Embed[F, R]): A => R =
-    scheme.hylo[F, Free[F, A], R](
+    kernel.hylo[F, Free[F, A], R](
       embed.algebra.run,
       _.fold(coalgebra.run, identity)
     ) compose (Free.pure(_))
@@ -92,7 +92,7 @@ private[droste] trait Zoo {
     algebra: CVAlgebra[F, B],
     coalgebra: CVCoalgebra[F, A]
   ): A => B =
-    scheme.hylo[F, Free[F, A], Cofree[F, B]](
+    kernel.hylo[F, Free[F, A], Cofree[F, B]](
       fb => Cofree(algebra(fb), fb),
       _.fold(coalgebra.run, identity)
     ) andThen (_.head) compose (Free.pure(_))
@@ -108,7 +108,7 @@ private[droste] trait Zoo {
     algebra: CVAlgebra[F, B],
     coalgebra: Coalgebra[F, A]
   ): A => B =
-    scheme.hylo[F, A, Cofree[F, B]](
+    kernel.hylo[F, A, Cofree[F, B]](
       fb => Cofree(algebra(fb), fb),
       coalgebra.run
     ) andThen (_.head)

--- a/modules/tests/src/test/scala/qq/droste/examples/mathexpr/MathExpr.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/mathexpr/MathExpr.scala
@@ -43,8 +43,8 @@ final class MathExprExample extends Properties("MathExprExample") {
   property("mu expressions") = {
 
     val toMu = scheme.hylo(
-      Mu.algebra[Expr[Double, ?]].run,
-      Fix.coalgebra[Expr[Double, ?]].run)
+      Mu.algebra[Expr[Double, ?]],
+      Fix.coalgebra[Expr[Double, ?]])
 
     val f1: Mu[Expr[Double, ?]] = toMu(Fix(Const(1.0)))
     val f2: Mu[Expr[Double, ?]] = toMu(Fix(Add(Fix(Const(1.0)), Fix(Const(2.0)))))
@@ -62,8 +62,8 @@ final class MathExprExample extends Properties("MathExprExample") {
   property("nu expressions") = {
 
     val toNu = scheme.hylo(
-      Nu.algebra[Expr[Double, ?]].run,
-      Fix.coalgebra[Expr[Double, ?]].run)
+      Nu.algebra[Expr[Double, ?]],
+      Fix.coalgebra[Expr[Double, ?]])
 
     val fixed: Fix[Expr[Double, ?]] = Fix(Add(Fix(Const(10.0)), Fix(Neg(Fix(Add(Fix(Const(1.0)), Fix(Const(2.0))))))))
     val z: Nu[Expr[Double, ?]] = toNu(fixed)

--- a/modules/tests/src/test/scala/qq/droste/tests/ListTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/ListTests.scala
@@ -44,7 +44,7 @@ final class ListTests extends Properties("ListTest") {
   property("rountrip List") = {
     // TODO: is there a way to rework/augment some of the schemes to return a
     // natural transformation valid for all lists?
-    val f = scheme.hylo(ListF.toScalaListAlgebra[String].run, ListF.fromScalaListCoalgebra[String].run)
+    val f = scheme.hylo(ListF.toScalaListAlgebra[String], ListF.fromScalaListCoalgebra[String])
     forAll((list: List[String]) => f(list) ?= list)
   }
 


### PR DESCRIPTION
This moves the function based hylo methods to a separate object. Now all methods in `scheme` take the algebra wrapper types.