### PR TITLE
Remove Tuple2 and Either aliases

### DIFF
--- a/athema/src/main/scala/qq/athema/algebras.scala
+++ b/athema/src/main/scala/qq/athema/algebras.scala
@@ -5,7 +5,6 @@ import algebra.ring.Ring
 import cats.implicits._
 
 import qq.droste._
-import qq.droste.data._
 import qq.droste.syntax.all._
 
 object Evaluate {
@@ -14,7 +13,7 @@ object Evaluate {
 
   def algebraM[V](
     variables: Map[String, V]
-  )(implicit V: Field[V]): AlgebraM[String | ?, Expr[V, ?], V] = AlgebraM {
+  )(implicit V: Field[V]): AlgebraM[Either[String, ?], Expr[V, ?], V] = AlgebraM {
     case Var  (name)  => variables.get(name).toRight(s"unknown variable: $name")
     case Const(v)     => v.asRight
     case Neg  (x)     => V.negate(x).asRight

--- a/modules/core/src/main/scala/qq/droste/implicits/composedFunctor.scala
+++ b/modules/core/src/main/scala/qq/droste/implicits/composedFunctor.scala
@@ -2,7 +2,7 @@ package qq.droste
 package implicits
 
 import cats.Functor
-import syntax.alias._
+import syntax.compose._
 
 object composedFunctor {
   implicit def drosteComposedFunctor[F[_], G[_]](

--- a/modules/core/src/main/scala/qq/droste/implicits/composedTraverse.scala
+++ b/modules/core/src/main/scala/qq/droste/implicits/composedTraverse.scala
@@ -2,7 +2,7 @@ package qq.droste
 package implicits
 
 import cats.Traverse
-import syntax.alias._
+import syntax.compose._
 
 object composedTraverse {
   implicit def drosteComposedTraverse[F[_], G[_]](

--- a/modules/core/src/main/scala/qq/droste/kernel.scala
+++ b/modules/core/src/main/scala/qq/droste/kernel.scala
@@ -10,7 +10,7 @@ import cats.syntax.traverse._
 
 import implicits.composedFunctor._
 import implicits.composedTraverse._
-import syntax.alias._
+import syntax.compose._
 
 /** Fundamental recursion schemes implemented in terms of
   * functions and nothing else.

--- a/modules/core/src/main/scala/qq/droste/syntax/package.scala
+++ b/modules/core/src/main/scala/qq/droste/syntax/package.scala
@@ -7,7 +7,7 @@ import data.AttrF
 import data.Fix
 
 object all
-    extends AliasSyntax
+    extends ComposeSyntax
     with AttrSyntax
     with LiftSyntax
     with FixSyntax
@@ -15,7 +15,7 @@ object all
     with EmbedSyntax
     with ProjectSyntax
 
-object alias extends AliasSyntax
+object compose extends ComposeSyntax
 object attr extends AttrSyntax
 object lift extends LiftSyntax
 object fix extends FixSyntax
@@ -23,7 +23,7 @@ object unfix extends UnfixSyntax
 object embed extends EmbedSyntax
 object project extends ProjectSyntax
 
-sealed trait AliasSyntax {
+sealed trait ComposeSyntax {
   /** Compose two functors `F` and `G`.
     *
     * This allows you to inline what would otherwise require
@@ -59,9 +59,6 @@ sealed trait AliasSyntax {
     * }}}
     */
   type ∘[F[_], G[_]] = { type λ[α] = F[G[α]] }
-
-  type &[L, R] = (L, R)
-  type |[L, R] = Either[L, R]
 }
 
 sealed trait AttrSyntax {

--- a/modules/core/src/main/scala/qq/droste/zoo.scala
+++ b/modules/core/src/main/scala/qq/droste/zoo.scala
@@ -7,10 +7,9 @@ import cats.instances.either._
 import cats.instances.tuple._
 import cats.syntax.functor._
 
-import data.prelude._
 import data.Attr
 import data.Coattr
-import syntax.alias._
+import data.prelude._
 
 private[droste] trait Zoo {
 
@@ -29,7 +28,7 @@ private[droste] trait Zoo {
     coalgebra: RCoalgebra[R, F, A]
   )(implicit embed: Embed[F, R]): A => R =
     kernel.hyloC(
-      embed.algebra.run.compose((frr: F[(R | R)]) => frr.map(_.merge)),
+      embed.algebra.run.compose((frr: F[(R Either R)]) => frr.map(_.merge)),
       coalgebra.run)
 
   /** A monadic version of an apomorphism.
@@ -43,7 +42,7 @@ private[droste] trait Zoo {
     coalgebraM: RCoalgebraM[R, M, F, A]
   )(implicit embed: Embed[F, R]): A => M[R] =
     kernel.hyloMC(
-      embed.algebra.lift[M].run.compose((frr: F[(R | R)]) => frr.map(_.merge)),
+      embed.algebra.lift[M].run.compose((frr: F[(R Either R)]) => frr.map(_.merge)),
       coalgebraM.run)
 
   /** A variation of a catamorphism that gives you access to the input value at

--- a/modules/tests/src/test/scala/qq/droste/examples/mathexpr/MathExpr.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/mathexpr/MathExpr.scala
@@ -10,7 +10,6 @@ import cats.implicits._
 import qq.droste._
 import qq.droste.data._
 import qq.droste.data.prelude._
-import qq.droste.syntax.alias._
 
 // note:
 // athema is a dummy math engine packaged with droste
@@ -21,7 +20,7 @@ final class MathExprExample extends Properties("MathExprExample") {
 
   def evalAlgebraMWithOverride[V: Field](
     variables: Map[String, V]
-  ): AlgebraM[String | ?, AttrF[Expr[V, ?], Option[V], ?], V] = AlgebraM {
+  ): AlgebraM[Either[String, ?], AttrF[Expr[V, ?], Option[V], ?], V] = AlgebraM {
     val algebra = Evaluate.algebraM(variables)
     fa => fa match {
       case AttrF(Some(value), _) => value.asRight


### PR DESCRIPTION
Removes the `|` and `&` aliases. I personally like them but think it'll be better to keep the library simpler by removing them.