### PR TITLE
Derive traverse

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ lazy val V = new {
   val refined    = "0.9.0"
   val algebra    = "1.0.0"
   val atto       = "0.6.2"
-  val kittens    = "1.1.0"
   val scalacheck = "1.13.5"
 }
 
@@ -38,7 +37,6 @@ lazy val coreJS  = core.js
 lazy val macros = module("macros")
   .dependsOn(core)
   .settings(libraryDependencies ++= Seq(
-    "org.typelevel" %%% "kittens" % V.kittens,
     compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.patch)
   ))
 

--- a/modules/macros/src/main/scala/qq/droste/macros/annotations.scala
+++ b/modules/macros/src/main/scala/qq/droste/macros/annotations.scala
@@ -4,9 +4,14 @@ import scala.language.experimental.macros
 import scala.annotation.StaticAnnotation
 import scala.annotation.compileTimeOnly
 
-import impl.deriveFixedPointMacro
+import impl.Macros
 
 @compileTimeOnly("enable macro paradise to expand macro annotations")
 class deriveFixedPoint extends StaticAnnotation {
-  def macroTransform(annottees: Any*): Any = macro deriveFixedPointMacro.impl
+  def macroTransform(annottees: Any*): Any = macro Macros.deriveFixedPoint
+}
+
+@compileTimeOnly("enable macro paradise to expand macro annotations")
+class deriveTraverse extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro Macros.deriveTraverse
 }

--- a/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
+++ b/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
@@ -62,18 +62,18 @@ object Macros {
             q"fn($t)"
           } else if(valDef.tpt.toString.contains(RecType)) {
             val T = valDef.tpt.asInstanceOf[AppliedTypeTree].tpt
-            q"cats.Traverse[$T].traverse($t)(fn)"
+            q"_root_.cats.Traverse[$T].traverse($t)(fn)"
           } else {
-            q"cats.Applicative[$G].pure($t)"
+            q"_root_.cats.Applicative[$G].pure($t)"
           }
         }
         val body = if (arity > 1) {
           val mapN: TermName = TermName(s"map${arity.toString}")
-          q"cats.Applicative[$G].$mapN(..$args)($name.apply[$B])"
+          q"_root_.cats.Applicative[$G].$mapN(..$args)($name.apply[$B])"
         } else if(arity == 1) {
-          q"cats.Applicative[$G].map($args.head)($name.apply[$B])"
+          q"_root_.cats.Applicative[$G].map($args.head)($name.apply[$B])"
         } else {
-          q"cats.Applicative[$G].pure($name[$B]())"
+          q"_root_.cats.Applicative[$G].pure($name[$B]())"
         }
 
         cq"$name(..$binds) => $body"
@@ -82,10 +82,10 @@ object Macros {
       val mtch = Match(Ident(TermName("fa")), cases)
 
       q"""
-      implicit def traverseInstance: cats.Traverse[$λ] = new qq.droste.util.DefaultTraverse[$λ] {
-        import cats.implicits._
+      implicit def traverseInstance: _root_.cats.Traverse[$λ] = new _root_.qq.droste.util.DefaultTraverse[$λ] {
+        import _root_.cats.implicits._
 
-        def traverse[$G[_]: cats.Applicative, $AA, $B](fa: $λ[$AA])(fn: $AA => $G[$B]): $G[$λ[$B]] = $mtch
+        def traverse[$G[_]: _root_.cats.Applicative, $AA, $B](fa: $λ[$AA])(fn: $AA => $G[$B]): $G[$λ[$B]] = $mtch
       }
       """
     }
@@ -215,18 +215,18 @@ object Macros {
             q"fn($t)"
           } else if(valDef.tpt.toString.contains(A.toString)) {
             val T = valDef.tpt.asInstanceOf[AppliedTypeTree].tpt
-            q"cats.Traverse[$T].traverse($t)(fn)"
+            q"_root_.cats.Traverse[$T].traverse($t)(fn)"
           } else {
-            q"cats.Applicative[$G].pure($t)"
+            q"_root_.cats.Applicative[$G].pure($t)"
           }
         }
         val body = if (arity > 1) {
           val mapN: TermName = TermName(s"map${arity.toString}")
-          q"cats.Applicative[$G].$mapN(..$args)($name.apply[$B])"
+          q"_root_.cats.Applicative[$G].$mapN(..$args)($name.apply[$B])"
         } else if(arity == 1) {
-          q"cats.Applicative[$G].map($args.head)($name.apply[$B])"
+          q"_root_.cats.Applicative[$G].map($args.head)($name.apply[$B])"
         } else {
-          q"cats.Applicative[$G].pure($name[$B]())"
+          q"_root_.cats.Applicative[$G].pure($name[$B]())"
         }
 
         cq"$name(..$binds) => $body"
@@ -235,10 +235,10 @@ object Macros {
       val mtch = Match(Ident(TermName("fa")), cases)
 
       q"""
-      implicit def traverseInstance[..${clait.tparams}]: cats.Traverse[λ] = new qq.droste.util.DefaultTraverse[λ] {
-        import cats.implicits._
+      implicit def traverseInstance[..${clait.tparams}]: _root_.cats.Traverse[λ] = new _root_.qq.droste.util.DefaultTraverse[λ] {
+        import _root_.cats.implicits._
 
-        def traverse[$G[_]: cats.Applicative, $AA, $B](fa: λ[$AA])(fn: $AA => $G[$B]): $G[λ[$B]] = $mtch
+        def traverse[$G[_]: _root_.cats.Applicative, $AA, $B](fa: λ[$AA])(fn: $AA => $G[$B]): $G[λ[$B]] = $mtch
       }
       """
     }
@@ -264,10 +264,10 @@ object Macros {
 
       val algebra =
         q"""
-        new qq.droste.GAlgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
+        new _root_.qq.droste.GAlgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
         """
 
-      q"def embedAlgebra[..${clait.tparams}]: qq.droste.Algebra[λ, ${clait.name}[..$claitTypeParamNames]] = $algebra"
+      q"def embedAlgebra[..${clait.tparams}]: _root_.qq.droste.Algebra[λ, ${clait.name}[..$claitTypeParamNames]] = $algebra"
 
     }
 
@@ -292,16 +292,16 @@ object Macros {
 
       val algebra =
         q"""
-        new qq.droste.GCoalgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
+        new _root_.qq.droste.GCoalgebra[λ, ${clait.name}[..$claitTypeParamNames], ${clait.name}[..$claitTypeParamNames]]($mtch)
         """
 
-      q"def projectCoalgebra[..${clait.tparams}]: qq.droste.Coalgebra[λ, ${clait.name}[..$claitTypeParamNames]] = $algebra"
+      q"def projectCoalgebra[..${clait.tparams}]: _root_.qq.droste.Coalgebra[λ, ${clait.name}[..$claitTypeParamNames]] = $algebra"
     }
 
     val basisInstance: DefDef = {
       q"""
-      implicit def basisInstance[..${clait.tparams}]: qq.droste.Basis[λ, ${clait.name}[..$claitTypeParamNames]] =
-        qq.droste.Basis.Default(embedAlgebra, projectCoalgebra)
+      implicit def basisInstance[..${clait.tparams}]: _root_.qq.droste.Basis[λ, ${clait.name}[..$claitTypeParamNames]] =
+        _root_.qq.droste.Basis.Default(embedAlgebra, projectCoalgebra)
       """
     }
 

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
@@ -1,0 +1,43 @@
+package qq.droste
+package examples
+
+import cats.instances.option._
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import qq.droste.data._
+import qq.droste.macros.deriveTraverse
+
+@deriveTraverse sealed trait ExprDerivingTraverse[A]
+object ExprDerivingTraverse {
+  final case class Const[A](value: BigDecimal) extends ExprDerivingTraverse[A]
+  final case class Add[A](x: A, y: A) extends ExprDerivingTraverse[A]
+  final case class AddList[A](list: List[A]) extends ExprDerivingTraverse[A]
+}
+
+final class DeriveTraverseChecks extends Properties("deriveTraverse") {
+  import ExprDerivingTraverse._
+
+  val summingAlgebraM: AlgebraM[Option, ExprDerivingTraverse, BigDecimal] = AlgebraM {
+    case Const(value) => Some(value)
+    case Add(x, y) => Some(x + y)
+    case AddList(list) => Some(list.reduce(_ + _))
+  }
+
+  val evaluate: Fix[ExprDerivingTraverse] => Option[BigDecimal] = scheme.cataM(summingAlgebraM)
+
+  property("1") =
+    evaluate(Fix(Const(1))) ?= Some(1)
+
+  property("1 + 1") =
+    evaluate(Fix(Add(Fix(Const(1)), Fix(Const(1))))) ?= Some(2)
+
+  property("1 + 2 + 5") =
+    evaluate(Fix(Add(Fix(Add(Fix(Const(1)), Fix(Const(2)))), Fix(Const(5))))) ?= Some(8)
+
+  property("1 + 2 + 3 + 4 + 5") =
+    evaluate(Fix(AddList(List(Fix(Const(1)), Fix(Const(2)), Fix(Const(3)), Fix(Const(4)), Fix(Const(5)))))) ?= Some(15)
+  
+
+}


### PR DESCRIPTION
This PR:

- Deletes the Kittens dependency (FIXES #57)
- Makes `@deriveFixedPoint` annotation derive a traverse instance instead of a functor one. See test.
- introduces a new  `@deriveTraverse` annotation that can annotate fixed point ADTs and put a derived traverse instance in the companion. (RE: #57)

##  deriving traverse

The algorithm for deriving traverse is fairly simple.  First we lift all the elements on the case class to the applicative context as follows:

1. if the field of the case class is recursive, we apply the traversing function `A => G[B]` to it.
2. If recursion happens on an `AppliedTypeTree` such as `List`, `Option`... we use the implicit `Traverse` instance on it (hoping it exists) and just `Traverse[T].traverse` it.
3. if it's neither of those, we just `Applicative[G].pure` it.

After that, depending on the arity of the case class, we do one of the following:

1. If the arity is > 1, we use Applicative.mapN combinator (N = arity)
2. if the arity is 1, we use Functor.map
3. if the arity is 0, we use Applicative.pure

## Caveats:

Currently, the code for deriving `Traverse` in the standalone annotation and in `@deriveFixedPoint` is copied, because I don't really know how to put it somewhere that can be shared in both implementations.  This is because of path dependent types on `blackbox.Context`.