### PR TITLE
Foldable operations on Project

### DIFF
--- a/modules/core/src/main/scala/qq/droste/data/list.scala
+++ b/modules/core/src/main/scala/qq/droste/data/list.scala
@@ -5,6 +5,7 @@ package list
 import cats.Applicative
 import cats.Traverse
 import cats.kernel.{Monoid, Eq}
+import cats.instances.list._
 import cats.syntax.applicative._
 import cats.syntax.functor._
 
@@ -57,7 +58,6 @@ object ListF {
       }
     }
 
-  implicit def basisListFEq[T, A](implicit T: Basis[ListF[A, ?], T]): Eq[T] =
+  implicit def basisListFEq[T, A](implicit T: Project[ListF[A, ?], T]): Eq[T] =
     Eq.fromUniversalEquals
-
 }

--- a/modules/core/src/main/scala/qq/droste/data/list.scala
+++ b/modules/core/src/main/scala/qq/droste/data/list.scala
@@ -4,6 +4,7 @@ package list
 
 import cats.Applicative
 import cats.Traverse
+import cats.kernel.{Monoid, Eq}
 import cats.syntax.applicative._
 import cats.syntax.functor._
 
@@ -43,4 +44,20 @@ object ListF {
           case NilF              => (NilF: ListF[A, C]).pure[F]
         }
     }
+
+  implicit def basisListFMonoid[T, A](implicit T: Basis[ListF[A, ?], T])
+      : Monoid[T] =
+    new Monoid[T] {
+      def empty = T.algebra(NilF)
+      def combine(f1: T, f2: T): T = {
+        scheme.cata(Algebra[ListF[A, ?], T] {
+          case NilF => f2
+          case cons   => T.algebra(cons)
+        }).apply(f1)
+      }
+    }
+
+  implicit def basisListFEq[T, A](implicit T: Basis[ListF[A, ?], T]): Eq[T] =
+    Eq.fromUniversalEquals
+
 }

--- a/modules/core/src/main/scala/qq/droste/syntax/package.scala
+++ b/modules/core/src/main/scala/qq/droste/syntax/package.scala
@@ -1,10 +1,12 @@
 package qq.droste
 package syntax
 
-import cats.Applicative
+import cats.{Applicative, Foldable, Monad}
+import cats.kernel.{Monoid, Eq}
 
-import data.AttrF
-import data.Fix
+import data.{AttrF, Fix}
+import data.list._
+
 
 object all
     extends ComposeSyntax
@@ -106,35 +108,77 @@ object UnfixSyntax {
 }
 
 sealed trait EmbedSyntax {
-  implicit def toEmbedSyntaxOps[F[_], T](t: F[T])(implicit Embed: Embed[F, T]): EmbedSyntax.Ops[F, T] =
+  implicit def toEmbedSyntaxOps[F[_], T](t: F[T])(implicit E: Embed[F, T]): EmbedSyntax.Ops[F, T] =
     new EmbedSyntax.Ops[F, T] {
-      def tc   = Embed
+      def Embed   = E
       def self = t
     }
 }
 
 object EmbedSyntax {
   trait Ops[F[_], T] {
-    def tc: Embed[F, T]
+    def Embed: Embed[F, T]
     def self: F[T]
 
-    def embed: T = tc.algebra(self)
+    def embed: T = Embed.algebra(self)
   }
 }
 
 sealed trait ProjectSyntax {
-  implicit def toProjectSyntaxOps[F[_], T](t: T)(implicit Project: Project[F, T]): ProjectSyntax.Ops[F, T] =
+  implicit def toProjectSyntaxOps[F[_], T](t: T)(implicit P: Project[F, T]): ProjectSyntax.Ops[F, T] =
     new ProjectSyntax.Ops[F, T] {
-      def tc   = Project
+      def Project   = P
+      def self = t
+    }
+
+  implicit def toFoldableOps[F[_], T](t: T)(implicit P: Project[F, T], F: Foldable[F]): ProjectSyntax.FoldableOps[F, T] =
+    new ProjectSyntax.FoldableOps[F, T] {
+      def Project   = P
+      def Foldable  = F
       def self = t
     }
 }
 
 object ProjectSyntax {
   trait Ops[F[_], T] {
-    def tc: Project[F, T]
+    def Project: Project[F, T]
     def self: T
 
-    def project: F[T] = tc.coalgebra(self)
+    def project: F[T] = Project.coalgebra(self)
+  }
+
+  trait FoldableOps[F[_], T] extends Ops[F, T] {
+
+    import util.newtypes._
+
+    implicit def Foldable: Foldable[F]
+
+    def all(p: T ⇒ Boolean): Boolean =
+      Project.all(self)(p)
+
+    def any(p: T ⇒ Boolean): Boolean =
+      Project.any(self)(p)
+
+    def collect[U: Monoid, B]
+      (pf: PartialFunction[T, B])
+      (implicit U: Basis[ListF[B, ?], U])
+        : U =
+      Project.collect[U, B](self)(pf)
+
+    def contains
+      (c: T)
+      (implicit T: Eq[T])
+        : Boolean =
+      Project.contains(self, c)
+
+    def foldMap[Z: Monoid]
+      (f: T => Z)
+        : Z =
+      Project.foldMap(self)(f)
+
+    def foldMapM[M[_], Z]
+      (f: T => M[Z])
+      (implicit M: Monad[M], Z: Monoid[Z]): M[Z] =
+      Project.foldMapM(self)(f)
   }
 }

--- a/modules/core/src/main/scala/qq/droste/util/newtypes.scala
+++ b/modules/core/src/main/scala/qq/droste/util/newtypes.scala
@@ -1,0 +1,33 @@
+package qq.droste
+package util
+
+import cats.Monoid
+
+object newtypes {
+
+  final case class @@[A, B](unwrap: A)
+  object Tag {
+    def apply[A, B](a: A): A @@ B = @@(a)
+  }
+
+  object Tags {
+    sealed trait Conjunction
+    sealed trait Disjunction
+  }
+
+  implicit class BooleanOps(b: Boolean) {
+    def conjunction: Boolean @@ Tags.Conjunction = @@(b)
+    def disjunction: Boolean @@ Tags.Disjunction = @@(b)
+  }
+
+  implicit val conjunctionMonoid: Monoid[Boolean @@ Tags.Conjunction] = new Monoid[Boolean @@ Tags.Conjunction] {
+    def empty: Boolean @@ Tags.Conjunction = @@(true)
+    def combine(a: Boolean @@ Tags.Conjunction, b: Boolean @@ Tags.Conjunction): Boolean @@ Tags.Conjunction = @@(a.unwrap && b.unwrap)
+  }
+
+  implicit val disjunctionMonoid: Monoid[Boolean @@ Tags.Disjunction] = new Monoid[Boolean @@ Tags.Disjunction] {
+    def empty: Boolean @@ Tags.Disjunction = @@(false)
+    def combine(a: Boolean @@ Tags.Disjunction, b: Boolean @@ Tags.Disjunction): Boolean @@ Tags.Disjunction = @@(a.unwrap || b.unwrap)
+  }
+}
+

--- a/modules/core/src/main/scala/qq/droste/util/newtypes.scala
+++ b/modules/core/src/main/scala/qq/droste/util/newtypes.scala
@@ -6,9 +6,6 @@ import cats.Monoid
 object newtypes {
 
   final case class @@[A, B](unwrap: A)
-  object Tag {
-    def apply[A, B](a: A): A @@ B = @@(a)
-  }
 
   object Tags {
     sealed trait Conjunction

--- a/modules/tests/src/test/scala/qq/droste/examples/foldableOperationsOnProject.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/foldableOperationsOnProject.scala
@@ -1,0 +1,63 @@
+package qq.droste
+package examples
+
+import cats.instances.list._
+import cats.kernel.Eq
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import qq.droste.macros.deriveFixedPoint
+import qq.droste.syntax.all._
+
+@deriveFixedPoint sealed trait LExpr
+object LExpr {
+  case class Var(name: String) extends LExpr
+  case class App(fn: LExpr, param: LExpr) extends LExpr
+  case class Lam(name: String, param: LExpr) extends LExpr
+
+  def `var`[A](name: String): fixedpoint.LExprF[A] = fixedpoint.VarF(name)
+  def app[A](fn: A, param: A): fixedpoint.LExprF[A] = fixedpoint.AppF(fn, param)
+  def lam[A](name: String, param: A): fixedpoint.LExprF[A] = fixedpoint.LamF(name, param)
+
+  implicit val eq: Eq[LExpr] = Eq.fromUniversalEquals
+}
+
+final class FoldableOpsChecks extends Properties("foldableOperationsOnProject") {
+
+  import LExpr._
+  import LExpr.fixedpoint._
+
+  def tru[T: Basis[LExprF, ?]]: T =
+    lam[T]("a",
+      lam[T]("b",
+        lam[T]("c",
+          lam[T]("d",
+            lam[T]("e",
+              lam[T]("f",
+                `var`[T]("c").embed
+              ).embed
+            ).embed
+          ).embed
+        ).embed
+      ).embed
+    ).embed
+
+  property("collect") =
+    tru[LExpr].collect[List[String], String] {
+      case Lam(name, _) => name
+    } ?= List("a", "b", "c", "d", "e", "f")
+
+  property("any") =
+    tru[LExpr].any {
+      case Var(name) => true
+      case _ => false
+    } ?= true
+
+  property("contains") =
+    tru[LExpr].contains(Var("c")) ?= true
+
+  property("contains") =
+    tru[LExpr].contains(App(Lam("name", Var("x")), Var(""))) ?= false
+  
+}

--- a/modules/tests/src/test/scala/qq/droste/tests/ListTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/ListTests.scala
@@ -1,7 +1,10 @@
 package qq.droste
 package tests
 
-import org.scalacheck.Properties
+import cats.kernel.{Monoid, Eq}
+import cats.kernel.laws.discipline.MonoidTests
+
+import org.scalacheck.{Properties, Arbitrary, Gen}
 import org.scalacheck.Prop._
 
 import qq.droste.data.list._
@@ -48,4 +51,12 @@ final class ListTests extends Properties("ListTest") {
     forAll((list: List[String]) => f(list) ?= list)
   }
 
+  implicit def arbitrary[T]: Arbitrary[Fix[ListF[Int, ?]]] =
+    Arbitrary(Gen.listOf(Gen.posNum[Int]).map(ListF.fromScalaList[Int, Fix]))
+
+  implicit def monoid: Monoid[Fix[ListF[Int, ?]]] = ListF.basisListFMonoid[Fix[ListF[Int, ?]], Int]
+
+  implicit val eq: Eq[Fix[ListF[Int, ?]]] = ListF.basisListFEq[Fix[ListF[Int, ?]], Int]
+
+  include(MonoidTests[Fix[ListF[Int, ?]]].monoid.all)
 }

--- a/modules/tests/src/test/scala/qq/droste/tests/newtypes.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/newtypes.scala
@@ -1,0 +1,28 @@
+package qq.droste
+package tests
+
+import cats.kernel.laws.discipline.MonoidTests
+import cats.instances.boolean._
+import cats.Eq
+
+import qq.droste.util.newtypes._
+
+import org.scalacheck._
+
+final class NewtypesTests extends Properties("newtypes") {
+
+  implicit val conjunctionArbitrary: Arbitrary[Boolean @@ Tags.Conjunction] =
+    Arbitrary(Gen.oneOf(true, false).map(_.conjunction))
+
+  implicit val disjunctionArbitrary: Arbitrary[Boolean @@ Tags.Disjunction] =
+    Arbitrary(Gen.oneOf(true, false).map(_.disjunction))
+
+  implicit val conjunctionEq: Eq[Boolean @@ Tags.Conjunction] =
+    Eq.by(_.unwrap)
+
+  implicit val disjunctionEq: Eq[Boolean @@ Tags.Disjunction] =
+    Eq.by(_.unwrap)
+    
+  include(MonoidTests[Boolean @@ Tags.Conjunction].monoid.all, "conjunction.")
+  include(MonoidTests[Boolean @@ Tags.Disjunction].monoid.all, "disjunction.")
+}


### PR DESCRIPTION
This PR:

- Introduces some `Foldable` like operations on `Project` typeclass
- Creates syntax for those
- Introduces a simple type tagging case class `@@` if agreed, it can be substituted with a proper newtypes library like https://github.com/julien-truffaut/newts or https://github.com/alexknvl/newtypes
- creates two newtypes for boolean (conjunction & disjunction)
- creates Eq & Monoid instances for `T: Basis[ListF, ?]`