### PR TITLE
Change some suspicious flatMaps to maps

### DIFF
--- a/modules/tests/src/test/scala/qq/droste/tests/AttrTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/AttrTests.scala
@@ -20,7 +20,7 @@ final class AttrTests extends Properties("Attr") {
       scheme.anaM(CoalgebraM((size: Int) =>
         (
           arbitrary[A],
-          Gen.choose(0, size).flatMap(n => if (n > 0) Some(n) else None)
+          Gen.choose(0, size).map(n => if (n > 0) Some(n) else None)
         ) mapN (AttrF(_, _))
       )).apply(maxSize)))
 

--- a/modules/tests/src/test/scala/qq/droste/tests/FixTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/FixTests.scala
@@ -15,7 +15,7 @@ final class FixTests extends Properties("Fix") {
   implicit val arbFixOption: Arbitrary[Fix[Option]] =
     Arbitrary(Gen.sized(maxSize =>
       scheme.anaM(CoalgebraM((size: Int) =>
-        Gen.choose(0, size).flatMap(n =>
+        Gen.choose(0, size).map(n =>
           if (n > 0) Some(n) else None))).apply(maxSize)))
 
   include(BasisLaws.props[Option, Fix[Option]](

--- a/modules/tests/src/test/scala/qq/droste/tests/MuTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/MuTests.scala
@@ -15,7 +15,7 @@ final class MuTests extends Properties("Mu") {
   implicit val arbMuOption: Arbitrary[Mu[Option]] =
     Arbitrary(Gen.sized(maxSize =>
       scheme[Mu].anaM(CoalgebraM((size: Int) =>
-        Gen.choose(0, size).flatMap(n =>
+        Gen.choose(0, size).map(n =>
           if (n > 0) Some(n) else None))).apply(maxSize)))
 
   include(BasisLaws.props[Option, Mu[Option]](


### PR DESCRIPTION
There were a few Scalacheck generators that were using `flatMap` when
they conceptually were performing a `map`. Unfortunately since
`Gen.const` in Scalacheck is defined as an implicit conversion, this was
being masked. The end behavior should be the same, but this is probably
more straightforward.