### PR TITLE
Add the "g" version of folds and unfolds to SchemePartialBasis

### DIFF
--- a/modules/core/src/main/scala/qq/droste/scheme.scala
+++ b/modules/core/src/main/scala/qq/droste/scheme.scala
@@ -97,6 +97,16 @@ private[droste] sealed trait SchemeConvenientPorcelain {
     )(implicit embed: EmbedP[F], ev: TraverseP[F]): A => M[PatR[F]] =
       scheme.anaM[M, PatF[F, ?], A, PatR[F]](coalgebraM)
 
+    def gana[F[_], A, S](
+      scattered: GCoalgebra.Scattered[PatF[F, ?], A, S]
+    )(implicit embed: EmbedP[F], ev: FunctorP[F]): A => PatR[F] =
+      scheme.gana[PatF[F, ?], A, S, PatR[F]](scattered.coalgebra)(scattered.scatter)
+
+    def ganaM[M[_]: Monad, F[_], A, S](
+      scattered: GCoalgebraM.Scattered[M, PatF[F, ?], A, S]
+    )(implicit embed: EmbedP[F], ev: TraverseP[F]): A => M[PatR[F]] =
+      scheme.ganaM[M, PatF[F, ?], A, S, PatR[F]](scattered)
+
     def cata[F[_], B](
       algebra: Algebra[PatF[F, ?], B]
     )(implicit project: ProjectP[F], ev: FunctorP[F]): PatR[F] => B =
@@ -106,6 +116,16 @@ private[droste] sealed trait SchemeConvenientPorcelain {
       algebraM: AlgebraM[M, PatF[F, ?], B]
     )(implicit project: ProjectP[F], ev: TraverseP[F]): PatR[F] => M[B] =
       scheme.cataM[M, PatF[F, ?], PatR[F], B](algebraM)
+
+    def gcata[F[_], S, B](
+      gathered: GAlgebra.Gathered[PatF[F, ?], S, B]
+    )(implicit project: ProjectP[F], ev: FunctorP[F]): PatR[F] => B =
+      scheme.gcata[PatF[F, ?], PatR[F], S, B](gathered.algebra)(gathered.gather)
+
+    def gcataM[M[_]: Monad, F[_], S, B](
+      gathered: GAlgebraM.Gathered[M, PatF[F, ?], S, B]
+    )(implicit project: ProjectP[F], ev: TraverseP[F]): PatR[F] => M[B] =
+      scheme.gcataM[M, PatF[F, ?], PatR[F], S, B](gathered)
 
   }
 

--- a/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/SchemePartialBasisTests.scala
@@ -18,9 +18,16 @@ import data.Attr
 import data.Fix
 import data.Mu
 import data.Nu
+import data.list._
 import syntax.attr._
 
 class SchemePartialBasisTests extends Properties("SchemePartialBasis") {
+  val sumListFIntAlgebra: Algebra[ListF[Int, ?], Int]  = Algebra {
+    case ConsF(x, y) => x + y
+    case NilF => 0
+  }
+
+  def sumListInt(l: List[Int]): Int = l.foldLeft(0)(_ + _)
 
   property("scheme[Fix].ana") = {
 
@@ -82,4 +89,48 @@ class SchemePartialBasisTests extends Properties("SchemePartialBasis") {
     forAll((n: Int Refined Less[W.`100`.T]) => f(n) ?= expected(n))
   }
 
+  property("scheme[Mu].cata") = {
+
+    val f = scheme[Mu].cata(sumListFIntAlgebra)
+
+    forAll((l: List[Int]) => f(ListF.fromScalaList[Int, Mu](l)) ?= sumListInt(l))
+  }
+
+  property("scheme[Mu].gcata") = {
+
+    val f = scheme[Mu].gcata(sumListFIntAlgebra.gather(Gather.cata))
+
+    forAll((l: List[Int]) => f(ListF.fromScalaList[Int, Mu](l)) ?= sumListInt(l))
+  }
+
+  property("scheme[Mu].gcataM") = {
+
+    val f = scheme[Mu].gcataM(sumListFIntAlgebra.lift[Eval].gather(Gather.cata))
+
+    forAll((l: List[Int]) => f(ListF.fromScalaList[Int, Mu](l)).value ?= sumListInt(l))
+  }
+
+  property("scheme[Mu].gana") = {
+
+    val f = scheme[Mu].gana(
+      Coalgebra((n: Int) => if (n > 0) Some(n - 1) else None).scatter(Scatter.ana))
+
+    def expected(n: Int): Mu[Option] =
+      if (n > 0) Mu(Some(expected(n - 1)))
+      else Mu(None: Option[Mu[Option]])
+
+    forAll((n: Int Refined Less[W.`100`.T]) => f(n) ?= expected(n))
+  }
+
+  property("scheme[Mu].ganaM") = {
+
+    val f = scheme[Mu].ganaM(
+      Coalgebra((n: Int) => if (n > 0) Some(n - 1) else None).lift[Eval].scatter(Scatter.ana))
+
+    def expected(n: Int): Mu[Option] =
+      if (n > 0) Mu(Some(expected(n - 1)))
+      else Mu(None: Option[Mu[Option]])
+
+    forAll((n: Int Refined Less[W.`100`.T]) => f(n).value ?= expected(n))
+  }
 }


### PR DESCRIPTION
In some code that I just wrote this saved me from needing to write a
long chain of type parameters when using `gcata`. Having said that, I
don't really know what I'm doing, so let me know if this doesn't make
sense.

If this change is welcome I can look into writing tests for it.