### PR TITLE
Add unapply methods for data types

### DIFF
--- a/modules/core/src/main/scala/qq/droste/data/Attr.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Attr.scala
@@ -14,7 +14,7 @@ object Attr {
   def apply  [F[_], A](head: A, tail: F[Attr[F, A]]): Attr[F, A] = apply((head, tail))
   def apply  [F[_], A](f: (A, F[Attr[F, A]])): Attr[F, A] = macro Meta.fastCast
   def un     [F[_], A](f: Attr[F, A]): (A, F[Attr[F, A]]) = macro Meta.fastCast
-  def unapply[F[_], A](f: Attr[F, A]): Option[(A, F[Attr[F,A]])] = Some(f.tuple)
+  def unapply[F[_], A](f: Attr[F, A]): Some[(A, F[Attr[F,A]])] = Some(f.tuple)
 
   def algebra[F[_], A]: Algebra[AttrF[F, A, ?], Attr[F, A]] =
     Algebra(fa => Attr(AttrF.un(fa)))

--- a/modules/core/src/main/scala/qq/droste/data/AttrF.scala
+++ b/modules/core/src/main/scala/qq/droste/data/AttrF.scala
@@ -17,7 +17,7 @@ object AttrF {
   def apply  [F[_], A, B](ask: A, lower: F[B]): AttrF[F, A, B] = apply((ask, lower))
   def apply  [F[_], A, B](f: (A, F[B])): AttrF[F, A, B] = macro Meta.fastCast
   def un     [F[_], A, B](f: AttrF[F, A, B]): (A, F[B]) = macro Meta.fastCast
-  def unapply[F[_], A, B](f: AttrF[F, A, B]): Option[(A, F[B])] = Some(f.tuple)
+  def unapply[F[_], A, B](f: AttrF[F, A, B]): Some[(A, F[B])] = Some(f.tuple)
 }
 
 private[data] trait AttrFImplicits extends AttrFImplicits0 {

--- a/modules/core/src/main/scala/qq/droste/data/Coattr.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Coattr.scala
@@ -15,6 +15,20 @@ object Coattr {
 
   def coalgebra[F[_], A]: Coalgebra[CoattrF[F, A, ?], Coattr[F, A]] =
     Coalgebra(a => CoattrF(Coattr.un(a)))
+
+  object Pure {
+    def unapply[F[_], A](f: Coattr[F, A]): Option[A] = un(f) match {
+      case Left(a) => Some(a)
+      case _ => None
+    }
+  }
+
+  object Roll {
+    def unapply[F[_], A](f: Coattr[F, A]): Option[F[Coattr[F, A]]] = un(f) match {
+      case Right(fa) => Some(fa)
+      case _ => None
+    }
+  }
 }
 
 trait CoattrImplicits {

--- a/modules/core/src/main/scala/qq/droste/data/CoattrF.scala
+++ b/modules/core/src/main/scala/qq/droste/data/CoattrF.scala
@@ -18,6 +18,20 @@ object CoattrF {
 
   def pure  [F[_], A, B](a: A)    : CoattrF[F, A, B] = CoattrF(Left(a))
   def roll  [F[_], A, B](fb: F[B]): CoattrF[F, A, B] = CoattrF(Right(fb))
+
+  object Pure {
+    def unapply[F[_], A, B](f: CoattrF[F, A, B]): Option[A] = un(f) match {
+      case Left(a) => Some(a)
+      case _ => None
+    }
+  }
+
+  object Roll {
+    def unapply[F[_], A, B](f: CoattrF[F, A, B]): Option[F[B]] = un(f) match {
+      case Right(fa) => Some(fa)
+      case _ => None
+    }
+  }
 }
 
 private[data] trait CoattrFImplicits extends CoenvtTImplicits0 {

--- a/modules/core/src/main/scala/qq/droste/data/Fix.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Fix.scala
@@ -7,6 +7,8 @@ object Fix {
   def apply[F[_]](f: F[Fix[F]]): Fix[F]    = macro Meta.fastCast
   def un   [F[_]](f: Fix[F])   : F[Fix[F]] = macro Meta.fastCast
 
+  def unapply[F[_]](f: Fix[F]): Some[F[Fix[F]]] = Some(un(f))
+
   def algebra  [F[_]]: Algebra  [F, Fix[F]] = Algebra(apply(_))
   def coalgebra[F[_]]: Coalgebra[F, Fix[F]] = Coalgebra(un(_))
 }

--- a/modules/core/src/main/scala/qq/droste/data/Mu.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Mu.scala
@@ -26,6 +26,8 @@ object Mu {
   def apply[F[_]: Functor](fmf: F[Mu[F]]):   Mu[F]  = algebra  [F].apply(fmf)
   def un   [F[_]: Functor](mf :   Mu[F] ): F[Mu[F]] = coalgebra[F].apply(mf)
 
+  def unapply[F[_]: Functor](mf: Mu[F]): Some[F[Mu[F]]] = Some(un(mf))
+
   private final case class Default[F[_]: Functor](fmf: F[Mu[F]]) extends Mu[F] {
     def apply[A](fold: Algebra[F, A]): Id[A] =
       fold(fmf map (mf => mf(fold)))

--- a/modules/core/src/main/scala/qq/droste/data/Nu.scala
+++ b/modules/core/src/main/scala/qq/droste/data/Nu.scala
@@ -32,6 +32,8 @@ object Nu {
   def apply  [F[_]: Functor](fnf: F[Nu[F]]):   Nu[F]  = algebra  [F].apply(fnf)
   def un     [F[_]: Functor](nf :   Nu[F] ): F[Nu[F]] = coalgebra[F].apply(nf)
 
+  def unapply[F[_]: Functor](nf : Nu[F]): Some[F[Nu[F]]] = Some(un(nf))
+
   private final case class Default[F[_]](unfold: Coalgebra[F, F[Nu[F]]], a: F[Nu[F]]) extends Nu[F]
 
   // Arranged so that equality is done only over the value `a`. This

--- a/modules/tests/src/test/scala/qq/droste/tests/AttrTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/AttrTests.scala
@@ -8,6 +8,7 @@ import laws.BasisLaws
 import scalacheck._
 
 import org.scalacheck.Properties
+import org.scalacheck.Prop._
 
 import cats.implicits._
 import cats.laws.discipline.TraverseTests
@@ -18,5 +19,13 @@ final class AttrTests extends Properties("Attr/AttrF") {
     "AttrF[Int, Option, ?]", "Attr[Option, Int]"))
 
   include(TraverseTests[AttrF[Option, Int, ?]].traverse[Int, Int, Int, Int, Option, Option].all)
+
+  property("unapply") = {
+    forAll((x: Attr[Option, Int]) =>
+      x match {
+        case Attr((i, fa)) => x ?= Attr(i, fa)
+      }
+    )
+  }
 
 }

--- a/modules/tests/src/test/scala/qq/droste/tests/CoattrFTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/CoattrFTests.scala
@@ -1,0 +1,20 @@
+package qq.droste
+package tests
+
+import data.CoattrF
+import scalacheck._
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+final class CoattrFTests extends Properties("CoattrF") {
+
+  property("unapply") = {
+    forAll((x: CoattrF[Option, Int, Long]) =>
+      x match {
+        case CoattrF.Pure(i) => CoattrF.un(x).left.toOption ?= Some(i)
+        case CoattrF.Roll(fi) => CoattrF.un(x).toOption ?= Some(fi)
+      }
+    )
+  }
+}

--- a/modules/tests/src/test/scala/qq/droste/tests/CoattrTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/CoattrTests.scala
@@ -1,0 +1,22 @@
+package qq.droste
+package tests
+
+import data.Coattr
+import scalacheck._
+
+import org.scalacheck.Properties
+import org.scalacheck.Prop._
+
+import cats.instances.option._
+
+final class CoattrTests extends Properties("Coattr") {
+
+  property("unapply") = {
+    forAll((x: Coattr[Option, Int]) =>
+      x match {
+        case Coattr.Pure(i) => Coattr.un(x).left.toOption ?= Some(i)
+        case Coattr.Roll(fi) => Coattr.un(x).toOption ?= Some(fi)
+      }
+    )
+  }
+}

--- a/modules/tests/src/test/scala/qq/droste/tests/FixTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/FixTests.scala
@@ -6,6 +6,7 @@ import laws.BasisLaws
 import scalacheck._
 
 import org.scalacheck.Properties
+import org.scalacheck.Prop._
 
 import cats.instances.option._
 
@@ -14,4 +15,11 @@ final class FixTests extends Properties("Fix") {
   include(BasisLaws.props[Option, Fix[Option]](
     "Option", "Fix[Option]"))
 
+  property("unapply") = {
+    forAll((x: Fix[Option]) =>
+      x match {
+        case Fix(y) => y ?= Fix.un(x)
+      }
+    )
+  }
 }

--- a/modules/tests/src/test/scala/qq/droste/tests/MuTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/MuTests.scala
@@ -6,6 +6,7 @@ import laws.BasisLaws
 import scalacheck._
 
 import org.scalacheck.Properties
+import org.scalacheck.Prop._
 
 import cats.instances.option._
 
@@ -14,4 +15,11 @@ final class MuTests extends Properties("Mu") {
   include(BasisLaws.props[Option, Mu[Option]](
     "Option", "Mu[Option]"))
 
+  property("unapply") = {
+    forAll((x: Mu[Option]) =>
+      x match {
+        case Mu(y) => y ?= Mu.un(x)
+      }
+    )
+  }
 }

--- a/modules/tests/src/test/scala/qq/droste/tests/NuTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/NuTests.scala
@@ -6,6 +6,7 @@ import laws.BasisLaws
 import scalacheck._
 
 import org.scalacheck.Properties
+import org.scalacheck.Prop._
 
 import cats.instances.option._
 
@@ -14,4 +15,11 @@ final class NuTests extends Properties("Nu") {
   include(BasisLaws.props[Option, Nu[Option]](
     "Option", "Nu[Option]"))
 
+  property("unapply") = {
+    forAll((x: Nu[Option]) =>
+      x match {
+        case Nu(y) => y ?= Nu.un(x)
+      }
+    )
+  }
 }


### PR DESCRIPTION
In a project that I'm working on, I found these unapply methods helpful
when matching on nested structures to apply optimizations.

I didn't see any existing `Gen` instances for `Coattr` or `CoattrF` so I
wrote my own. I'm not too sure about the `Coattr` instance; please take
a close look at that one.

I made the return types of the `unapply` methods `Some[A]` as opposed to `Option[A]` for methods that always return a `Some`. This seems a little strange, but in general this makes the pattern irrefutable so the exhaustiveness checker knows that it can't fail. I'm unsure whether that matters for the types that are macro-based newtypes, but it seemed like the right thing to do? 