### PR TITLE
Reform DefaultTraverse

### DIFF
--- a/modules/core/src/main/scala/qq/droste/util/DefaultTraverse.scala
+++ b/modules/core/src/main/scala/qq/droste/util/DefaultTraverse.scala
@@ -8,13 +8,15 @@ import cats.arrow.Category
 import cats.data.Const
 
 import cats.instances.function._
+import cats.instances.list._
 
 trait DefaultTraverse[F[_]] extends Traverse[F] {
   override def foldMap[A, B: Monoid](fa: F[A])(f: A => B): B =
     traverse(fa)(a => Const[B, B](f(a))).getConst
 
   def foldLeft[A, B](fa: F[A], b: B)(f: (B, A) => B): B =
-    foldMap[A, B => B](fa)(a => bb => f(bb, a))(Category[Function1].algebra)(b)
+    foldMap[A,List[A]](fa)(_ :: Nil)(Monoid[List[A]])
+      .foldLeft(b)(f)
 
   def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
     foldMap[A, Eval[B] => Eval[B]](fa)(a => lbb => Eval.defer(f(a, lbb)))(

--- a/modules/tests/src/test/scala/qq/droste/tests/DefaultTraverseTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/DefaultTraverseTests.scala
@@ -24,8 +24,6 @@ object Pair {
   )
 }
 
-
-
 final class DefaultTraverseTests extends Properties("DefaultTraverse") {
   implicit def arbPair[A](implicit arbA: Arbitrary[A]): Arbitrary[Pair[A]] = Arbitrary(
     arbA.arbitrary.flatMap(a1 => arbA.arbitrary.map(a2 => Pair(a1, a2))))

--- a/modules/tests/src/test/scala/qq/droste/tests/DefaultTraverseTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/DefaultTraverseTests.scala
@@ -28,7 +28,6 @@ final class DefaultTraverseTests extends Properties("DefaultTraverse") {
   implicit def arbPair[A](implicit arbA: Arbitrary[A]): Arbitrary[Pair[A]] = Arbitrary(
     arbA.arbitrary.flatMap(a1 => arbA.arbitrary.map(a2 => Pair(a1, a2))))
 
-  // checkAll("Pair", TraverseTests[Pair].traverse[Int, Int, Int, Set[Int], Option, Option])
   include(TraverseTests[Pair].traverse[Int, Int, Int, Set[Int], Option, Option].all)
 }
 

--- a/modules/tests/src/test/scala/qq/droste/tests/DefaultTraverseTests.scala
+++ b/modules/tests/src/test/scala/qq/droste/tests/DefaultTraverseTests.scala
@@ -1,0 +1,37 @@
+package qq.droste
+package tests
+
+
+import cats.implicits._
+import qq.droste.util.DefaultTraverse
+import cats.{Applicative, Eq, Traverse}
+import org.scalacheck.Arbitrary
+import cats.laws.discipline.TraverseTests
+
+import org.scalacheck.Properties
+
+final case class Pair[A](l: A, r: A)
+
+object Pair {
+
+  implicit val traversePair: Traverse[Pair] = new DefaultTraverse[Pair] {
+    def traverse[G[_], A, B](fa: Pair[A])(f: A => G[B])(implicit G: Applicative[G]): G[Pair[B]] =
+      G.map2(f(fa.l), f(fa.r))(Pair(_, _))
+  }
+
+  implicit def eqPair[A](implicit eqA: Eq[A]): Eq[Pair[A]] = Eq.instance((p1, p2) =>
+    p1.l === p2.l && p1.r === p2.r
+  )
+}
+
+
+
+final class DefaultTraverseTests extends Properties("DefaultTraverse") {
+  implicit def arbPair[A](implicit arbA: Arbitrary[A]): Arbitrary[Pair[A]] = Arbitrary(
+    arbA.arbitrary.flatMap(a1 => arbA.arbitrary.map(a2 => Pair(a1, a2))))
+
+  // checkAll("Pair", TraverseTests[Pair].traverse[Int, Int, Int, Set[Int], Option, Option])
+  include(TraverseTests[Pair].traverse[Int, Int, Int, Set[Int], Option, Option].all)
+}
+
+


### PR DESCRIPTION
Fixes DefaultTraverse's lawfulness by, for `foldLeft`, taking a trip through list consing instead of function composing. Otherwise we have a foldRight instead of foldLeft. 

The testcase is ripped from @ceedubs's #76 .