### PR TITLE
Fix arbitrary case classes on deriving companions

### DIFF
--- a/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
+++ b/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
@@ -33,8 +33,14 @@ object Macros {
     classOrTrait.mods.hasFlag(ABSTRACT) &&
     classOrTrait.mods.hasFlag(SEALED)
 
+    /**
+      * returns wether c extends d
+      */
+    def xtends(c: ClassDef, d: ClassDef): Boolean =
+      c.impl.parents.map(_.toString).exists(_.contains(d.name.toString))
+
     val isCase: PartialFunction[Tree, ClassDef] = {
-      case c: ClassDef if c.mods.hasFlag(CASE)  => c
+      case c: ClassDef if c.mods.hasFlag(CASE) && xtends(c, clait) => c
     }
 
     val AdtCases = companion.impl.body.collect(isCase)

--- a/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
+++ b/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
@@ -152,9 +152,17 @@ object Macros {
     classOrTrait.mods.hasFlag(ABSTRACT) &&
     classOrTrait.mods.hasFlag(SEALED)
 
+    /**
+      * returns wether c extends d
+      */
+    def xtends(c: Tree, d: ClassDef): Boolean = (c collect {
+      case c: ClassDef => c.impl.parents.map(_.toString).exists(_.contains(d.name.toString))
+      case c: ModuleDef => c.impl.parents.map(_.toString).exists(_.contains(d.name.toString))
+    }).contains(true)
+
     val isCase: PartialFunction[Tree, Tree] = {
-      case c: ClassDef if c.mods.hasFlag(CASE)  => c
-      case c: ModuleDef if c.mods.hasFlag(CASE) => c
+      case c: ClassDef if c.mods.hasFlag(CASE) && xtends(c, clait) => c
+      case c: ModuleDef if c.mods.hasFlag(CASE) && xtends(c, clait) => c
     }
 
     val AdtCases = companion.impl.body.collect(isCase)

--- a/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
+++ b/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
@@ -37,7 +37,7 @@ object Macros {
       * returns wether c extends d
       */
     def xtends(c: ClassDef, d: ClassDef): Boolean =
-      c.impl.parents.map(_.toString).exists(_.contains(d.name.toString))
+      c.impl.parents.map(_.toString).exists(_ == d.name.toString)
 
     val isCase: PartialFunction[Tree, ClassDef] = {
       case c: ClassDef if c.mods.hasFlag(CASE) && xtends(c, clait) => c
@@ -156,8 +156,8 @@ object Macros {
       * returns wether c extends d
       */
     def xtends(c: Tree, d: ClassDef): Boolean = (c collect {
-      case c: ClassDef => c.impl.parents.map(_.toString).exists(_.contains(d.name.toString))
-      case c: ModuleDef => c.impl.parents.map(_.toString).exists(_.contains(d.name.toString))
+      case c: ClassDef => c.impl.parents.map(_.toString).exists(_ == d.name.toString)
+      case c: ModuleDef => c.impl.parents.map(_.toString).exists(_ == d.name.toString)
     }).contains(true)
 
     val isCase: PartialFunction[Tree, Tree] = {

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveFixedPoint.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveFixedPoint.scala
@@ -3,6 +3,7 @@ package examples
 
 import org.scalacheck.Properties
 import org.scalacheck.Prop._
+import cats.instances.list._
 
 import qq.droste.macros.deriveFixedPoint
 

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveFixedPoint.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveFixedPoint.scala
@@ -8,6 +8,8 @@ import qq.droste.macros.deriveFixedPoint
 
 @deriveFixedPoint sealed trait RecursiveExpr
 object RecursiveExpr {
+  final case class Dummy()
+
   final case class Const(value: BigDecimal) extends RecursiveExpr
   final case class Add(x: RecursiveExpr, y: RecursiveExpr) extends RecursiveExpr
   final case class AddList(list: List[RecursiveExpr]) extends RecursiveExpr

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
@@ -11,6 +11,8 @@ import qq.droste.macros.deriveTraverse
 
 @deriveTraverse sealed trait ExprDerivingTraverse[A]
 object ExprDerivingTraverse {
+  final case class Dummy()
+
   final case class Const[A](value: BigDecimal) extends ExprDerivingTraverse[A]
   final case class Add[A](x: A, y: A) extends ExprDerivingTraverse[A]
   final case class AddList[A](list: List[A]) extends ExprDerivingTraverse[A]

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
@@ -2,6 +2,7 @@ package qq.droste
 package examples
 
 import cats.instances.option._
+import cats.instances.list._
 
 import org.scalacheck.Properties
 import org.scalacheck.Prop._


### PR DESCRIPTION
Previously, derivation failed when it detected arbitrary case classes in the body of the companion. This PR fixes that by checking correctly which case classes in the companion are part of the ADT.