### PR TITLE
add more fixes to traverse derivation

### DIFF
--- a/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
+++ b/modules/macros/src/main/scala/qq/droste/macros/impl/Macros.scala
@@ -101,17 +101,12 @@ object Macros {
             def getTraverseInstance(tt: AppliedTypeTree): Tree = {
               @tailrec def go(ttt: AppliedTypeTree, acc: Tree): Tree = ttt match {
                 case AppliedTypeTree(a: Ident, List(tttt@AppliedTypeTree(b: Ident, _))) =>
-                  val s = if (acc == EmptyTree)
-                    q"_root_.cats.Traverse[$a]"
-                  else
-                    acc
-
-                  go(tttt, q"$s.compose[$b]")
-                case AppliedTypeTree(_, _) =>
+                  go(tttt, q"$acc.compose[$b]")
+                case AppliedTypeTree(a: Ident, _) =>
                   acc
               }
 
-              go(tt, EmptyTree)
+              go(tt, q"_root_.cats.Traverse[${tt.tpt}]")
             }
 
             q"${getTraverseInstance(T)}.traverse($t)(fn)"

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
@@ -17,7 +17,7 @@ object ExprDerivingTraverse {
   final case class Dummy()
 
   final case class Const[A](value: BigDecimal) extends ExprDerivingTraverse[A]
-  final case class Add[A](x: A, y: A) extends ExprDerivingTraverse[A]
+  final case class Add[A](x: Box[A], y: A) extends ExprDerivingTraverse[A]
   final case class AddList[A](list: List[Box[Option[A]]]) extends ExprDerivingTraverse[A]
 }
 
@@ -26,7 +26,7 @@ final class DeriveTraverseChecks extends Properties("deriveTraverse") {
 
   val summingAlgebraM: AlgebraM[Option, ExprDerivingTraverse, BigDecimal] = AlgebraM {
     case Const(value) => Some(value)
-    case Add(x, y) => Some(x + y)
+    case Add(ExprDerivingTraverse.Box(_, x), y) => Some(x + y)
     case AddList(list) => list.map(_.a).sequence.map(_.reduce(_ + _))
   }
 
@@ -36,10 +36,10 @@ final class DeriveTraverseChecks extends Properties("deriveTraverse") {
     evaluate(Fix(Const(1))) ?= Some(1)
 
   property("1 + 1") =
-    evaluate(Fix(Add(Fix(Const(1)), Fix(Const(1))))) ?= Some(2)
+    evaluate(Fix(Add(Box("qwer", Fix(Const(1))), Fix(Const(1))))) ?= Some(2)
 
   property("1 + 2 + 5") =
-    evaluate(Fix(Add(Fix(Add(Fix(Const(1)), Fix(Const(2)))), Fix(Const(5))))) ?= Some(8)
+    evaluate(Fix(Add(Box("qwer", Fix(Add(Box("qwer", Fix(Const(1))), Fix(Const(2))))), Fix(Const(5))))) ?= Some(8)
 
   property("1 + 2 + 3 + 4 + 5") =
     evaluate(Fix(AddList(List(Box("asdf", Option(Fix(Const(1)))), Box("asdf", Option(Fix(Const(2)))), Box("asdf", Option(Fix(Const(3)))), Box("asdf", Option(Fix(Const(4)))), Box("asdf", Option(Fix(Const(5)))))))) ?= Some(15)

--- a/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
+++ b/modules/tests/src/test/scala/qq/droste/examples/deriveTraverse.scala
@@ -3,6 +3,7 @@ package examples
 
 import cats.instances.option._
 import cats.instances.list._
+import cats.syntax.traverse._
 
 import org.scalacheck.Properties
 import org.scalacheck.Prop._
@@ -12,11 +13,12 @@ import qq.droste.macros.deriveTraverse
 
 @deriveTraverse sealed trait ExprDerivingTraverse[A]
 object ExprDerivingTraverse {
+  @deriveTraverse final case class Box[A](name: String, a: A)
   final case class Dummy()
 
   final case class Const[A](value: BigDecimal) extends ExprDerivingTraverse[A]
   final case class Add[A](x: A, y: A) extends ExprDerivingTraverse[A]
-  final case class AddList[A](list: List[A]) extends ExprDerivingTraverse[A]
+  final case class AddList[A](list: List[Box[Option[A]]]) extends ExprDerivingTraverse[A]
 }
 
 final class DeriveTraverseChecks extends Properties("deriveTraverse") {
@@ -25,7 +27,7 @@ final class DeriveTraverseChecks extends Properties("deriveTraverse") {
   val summingAlgebraM: AlgebraM[Option, ExprDerivingTraverse, BigDecimal] = AlgebraM {
     case Const(value) => Some(value)
     case Add(x, y) => Some(x + y)
-    case AddList(list) => Some(list.reduce(_ + _))
+    case AddList(list) => list.map(_.a).sequence.map(_.reduce(_ + _))
   }
 
   val evaluate: Fix[ExprDerivingTraverse] => Option[BigDecimal] = scheme.cataM(summingAlgebraM)
@@ -40,7 +42,6 @@ final class DeriveTraverseChecks extends Properties("deriveTraverse") {
     evaluate(Fix(Add(Fix(Add(Fix(Const(1)), Fix(Const(2)))), Fix(Const(5))))) ?= Some(8)
 
   property("1 + 2 + 3 + 4 + 5") =
-    evaluate(Fix(AddList(List(Fix(Const(1)), Fix(Const(2)), Fix(Const(3)), Fix(Const(4)), Fix(Const(5)))))) ?= Some(15)
-  
+    evaluate(Fix(AddList(List(Box("asdf", Option(Fix(Const(1)))), Box("asdf", Option(Fix(Const(2)))), Box("asdf", Option(Fix(Const(3)))), Box("asdf", Option(Fix(Const(4)))), Box("asdf", Option(Fix(Const(5)))))))) ?= Some(15)
 
 }


### PR DESCRIPTION
Now @deriveTraverse:

- can annotate case classes:

```scala
  @deriveTraverse case class Potato[A](a: A)
```
- works when the recursive type appears deep in an AppliedTypeTree:

```scala
  @deriveTraverse sealed trait Adt[A]
  object Adt {
    case class ContainsLotsaPotatoes[A](potatoes: List[Potato[A]]) extends Adt[A]
  }
```